### PR TITLE
FIX: paramiko compatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim
 
-RUN pip install sshtunnel
+RUN pip install "paramiko<3.0" sshtunnel
 
 COPY entrypoint.py /entrypoint.py
 


### PR DESCRIPTION
Fixes runtime crash when establishing SSH tunnels due to paramiko version incompatibility.

Pin paramiko to <3.0 to resolve DSSKey AttributeError with sshtunnel library.

```
AttributeError: module 'paramiko' has no attribute 'DSSKey'. Did you mean: 'RSAKey'?

Traceback (most recent call last):

  File "/entrypoint.py", line 35, in <module>

    server = SSHTunnelForwarder(**kwargs)

  File "/usr/local/lib/python3.10/site-packages/sshtunnel.py", line 966, in __init__

    (self.ssh_password, self.ssh_pkeys) = self._consolidate_auth(

  File "/usr/local/lib/python3.10/site-packages/sshtunnel.py", line 1148, in _consolidate_auth

    ssh_loaded_pkeys = SSHTunnelForwarder.get_keys(

  File "/usr/local/lib/python3.10/site-packages/sshtunnel.py", line 1093, in get_keys

    'dsa': paramiko.DSSKey,
```